### PR TITLE
Enable wpa_s '-f' command line switch

### DIFF
--- a/board/qemu/wpa_sup_mesh_build.conf
+++ b/board/qemu/wpa_sup_mesh_build.conf
@@ -416,7 +416,7 @@ CONFIG_PEERKEY=y
 #CONFIG_IEEE80211R=y
 
 # Add support for writing debug log to a file (/tmp/wpa_supplicant-log-#.txt)
-#CONFIG_DEBUG_FILE=y
+CONFIG_DEBUG_FILE=y
 
 # Send debug messages to syslog instead of stdout
 #CONFIG_DEBUG_SYSLOG=y


### PR DESCRIPTION
This is required for meshkit to be able to launch wpa_supplicant in a
manner that allows it to track the daemon more easily.
