### PR TITLE
[PATCH] distro11s: better tag handling when FORCE_BUILD

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -54,7 +54,9 @@ function update_pkg {
 				git remote rm origin
 				git remote add origin ${URL}
 				git remote update origin
-				if [ "${BRANCH}" = "" ]; then
+				if [ "${TAG}" != "" ]; then
+					git checkout -q ${TAG}
+				elif [ "${BRANCH}" = "" ]; then
 					git branch -D ${BRANCH}
 					git checkout -b ${BRANCH} origin/${BRANCH}
 				else


### PR DESCRIPTION
```
From 27a15af49e3cd5b9d7f3202fbbd0b75db5ffe915 Mon Sep 17 00:00:00 2001
From: Jason Abele <jason@cozybit.com>
Date: Fri, 9 Aug 2013 10:40:53 -0700
Subject: [PATCH] distro11s: better tag handling when FORCE_BUILD

Signed-off-by: Jason Abele <jason@cozybit.com>

---
 scripts/common.sh |    4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

diff --git a/scripts/common.sh b/scripts/common.sh
index cb759d9..8e67af5 100644
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -54,7 +54,9 @@ function update_pkg {
                git remote rm origin
                git remote add origin ${URL}
                git remote update origin
-               if [ "${BRANCH}" = "" ]; then
+               if [ "${TAG}" != "" ]; then
+                   git checkout -q ${TAG}
+               elif [ "${BRANCH}" = "" ]; then
                    git branch -D ${BRANCH}
                    git checkout -b ${BRANCH} origin/${BRANCH}
                else
-- 
1.7.9.5

```
