### PR TITLE
[PATCH] distro11s-qemu: add host keys to known_hosts

### DIFF
--- a/scripts/qemu-cleanups.sh
+++ b/scripts/qemu-cleanups.sh
@@ -71,6 +71,14 @@ sudo chmod 644 -R ${STAGING}/root/
 sudo chmod 600 ${STAGING}/root/.ssh/id_rsa
 sudo chown -R root.root ${STAGING}/root
 
+# Install host keys in known_hosts
+echo "Updating known_hosts keys for ${DISTRO11S_STATIC_IP}"
+ssh-keygen -H -R ${DISTRO11S_STATIC_IP}:22
+for keyfile in `ls ${STAGING}/etc/ssh/ssh_host*_key`; do
+	echo ${DISTRO11S_STATIC_IP}:22 `sudo ssh-keygen -y -f ${keyfile}` >> ~/.ssh/known_hosts
+done
+ssh-keygen -H
+
 # set regulatory domain
 echo "configuring regulatory domain: ${DISTRO11S_REGDOMAIN}"
 echo "sed -i \"s/^REGDOMAIN=/REGDOMAIN=${DISTRO11S_REGDOMAIN}/\" ${STAGING}/etc/default/crda" | sudo sh


### PR DESCRIPTION
Final tests are still in progress, will update the pull-request later with results

Also, hopefully someone will consider how to clean up known-hosts for the zotac (and arm) boards

```
From 01b199445ef99ef61b243d64a1b21ca9759d9f1b Mon Sep 17 00:00:00 2001
From: Jason Abele <jason@cozybit.com>
Date: Thu, 12 Sep 2013 12:35:51 -0700
Subject: [PATCH] distro11s-qemu: add host keys to known_hosts

During qemu cleanups, it is nice to add/update the host keys in users
known_hosts file.

Signed-off-by: Jason Abele <jason@cozybit.com>

---
 scripts/qemu-cleanups.sh |    8 ++++++++
 1 file changed, 8 insertions(+)

diff --git a/scripts/qemu-cleanups.sh b/scripts/qemu-cleanups.sh
index 0ade485..51cfc6f 100755
--- a/scripts/qemu-cleanups.sh
+++ b/scripts/qemu-cleanups.sh
@@ -71,6 +71,14 @@ sudo chmod 644 -R ${STAGING}/root/
 sudo chmod 600 ${STAGING}/root/.ssh/id_rsa
 sudo chown -R root.root ${STAGING}/root

+# Install host keys in known_hosts
+echo "Updating known_hosts keys for ${DISTRO11S_STATIC_IP}"
+ssh-keygen -H -R ${DISTRO11S_STATIC_IP}:22
+for keyfile in `ls ${STAGING}/etc/ssh/ssh_host*_key`; do
+   echo ${DISTRO11S_STATIC_IP}:22 `sudo ssh-keygen -y -f ${keyfile}` >> ~/.ssh/known_hosts
+done
+ssh-keygen -H
+
 # set regulatory domain
 echo "configuring regulatory domain: ${DISTRO11S_REGDOMAIN}"
 echo "sed -i \"s/^REGDOMAIN=/REGDOMAIN=${DISTRO11S_REGDOMAIN}/\" ${STAGING}/etc/default/crda" | sudo sh
-- 
1.7.9.5

```
