### PR TITLE
set qemu memory in distro11s.conf

### DIFF
--- a/board/qemu/qemu.sh
+++ b/board/qemu/qemu.sh
@@ -68,6 +68,7 @@ fi
 [ -z "$DISTRO11S_VIRTFS_MOUNT_SRC" ] && DISTRO11S_VIRTFS_MOUNT_SRC="/home"
 ${QEMU} -nographic -kernel ${KERNEL} \
 	-hda ${ROOTFS} \
+	-m ${DISTRO11S_QEMU_MEMORY} \
 	-append "root=/dev/sda combined_mode=ide console=ttyS0" \
 	-fsdev local,id=modules,path=${STAGING}/lib/modules,security_model=mapped \
 	-fsdev local,id=misc,path=${DISTRO11S_VIRTFS_MOUNT_SRC},security_model=mapped \

--- a/distro11s.sample.conf
+++ b/distro11s.sample.conf
@@ -4,6 +4,10 @@
 # Target board
 DISTRO11S_BOARD=qemu
 
+# Target board memory
+# for example: 128M, 1G
+DISTRO11S_QEMU_MEMORY="128M"
+
 # Location where source should be checked out
 DISTRO11S_SRC=${PWD}/src
 


### PR DESCRIPTION
the test suite is running into memory issues on the jenkin's nightly build and
oom-killer is invoked for some tests.  i'd like to fix this by increasing the
qemu memory on jenkins so that the affected tests will be able to complete.
the default value will be the same amount as we normally give qemu (128M
default) and I will update jenkin's distro11s.conf to give the nightly build
512M.

oom-killer examples:
http://boo.local:8080/job/distro11s-hwsim-test/502/artifact/src/o11s-pvt/hwsim_tests/jenkins-run/secure-authsae-test-051-check-auth-protocol.sh.sys.log

http://boo.local:8080/job/distro11s-hwsim-test/502/artifact/src/o11s-pvt/hwsim_tests/jenkins-run/secure-authsae-test-046-probe-response.sh.sys.log

``` diff
From 588ea79583bb810e0ba585b0dd604f734071a99d Mon Sep 17 00:00:00 2001
From: Colleen Twitty <colleen@cozybit.com>
Date: Fri, 1 Nov 2013 16:05:40 -0700
Subject: [PATCH] qemu: set qemu memory in distro11s.conf

default to 128M in conf file.  since this is the qemu
default, this is always what we were using before, but now
it can changed easily in distro11s.conf.

---
 board/qemu/qemu.sh    |    1 +
 distro11s.sample.conf |    4 ++++
 2 files changed, 5 insertions(+)

diff --git a/board/qemu/qemu.sh b/board/qemu/qemu.sh
index f6060dc..0a7e53a 100755
--- a/board/qemu/qemu.sh
+++ b/board/qemu/qemu.sh
@@ -68,6 +68,7 @@ fi
 [ -z "$DISTRO11S_VIRTFS_MOUNT_SRC" ] && DISTRO11S_VIRTFS_MOUNT_SRC="/home"
 ${QEMU} -nographic -kernel ${KERNEL} \
    -hda ${ROOTFS} \
+   -m ${QEMU_MEMORY} \
    -append "root=/dev/sda combined_mode=ide console=ttyS0" \
    -fsdev local,id=modules,path=${STAGING}/lib/modules,security_model=mapped \
    -fsdev local,id=misc,path=${DISTRO11S_VIRTFS_MOUNT_SRC},security_model=mapped \
diff --git a/distro11s.sample.conf b/distro11s.sample.conf
index 42381f9..9868801 100644
--- a/distro11s.sample.conf
+++ b/distro11s.sample.conf
@@ -4,6 +4,10 @@
 # Target board
 DISTRO11S_BOARD=qemu

+# Target board memory
+# for example: 128M, 1G
+QEMU_MEMORY="128M"
+
 # Location where source should be checked out
 DISTRO11S_SRC=${PWD}/src

-- 
1.7.9.5

```
