### PR TITLE
allow configuration of debian release in distro11s.conf

### DIFF
--- a/distro11s.sample.conf
+++ b/distro11s.sample.conf
@@ -4,6 +4,9 @@
 # Target board
 DISTRO11S_BOARD=qemu
 
+# Debian release to use for building root filesystem (e.g. sid, testing, etc.)
+DISTRO11S_DEB_RELEASE=sid
+
 # Target board memory
 # for example: 128M, 1G
 DISTRO11S_QEMU_MEMORY="128M"

--- a/scripts/debian-rootfs.sh
+++ b/scripts/debian-rootfs.sh
@@ -13,14 +13,14 @@ if [ ! -e  ${STAMPS}/debian-rootfs.bootstrapped -o ${FORCE_BUILD} -eq 1 ]; then
 	sudo rm -rf ${STAGING}/*
 	case ${DISTRO11S_BOARD} in
 	zotac | qemu)
-		sudo debootstrap sid ${STAGING} http://ftp.debian.org/debian || exit 1
+		sudo debootstrap ${DISTRO11S_DEB_RELEASE} ${STAGING} http://ftp.debian.org/debian || exit 1
 	;;
 	arm-chroot)
-		sudo debootstrap --arch=armel --foreign sid ${STAGING} http://http.debian.net/debian || exit 1
+		sudo debootstrap --arch=armel --foreign ${DISTRO11S_DEB_RELEASE} ${STAGING} http://http.debian.net/debian || exit 1
 		sudo cp /usr/bin/qemu-arm-static ${STAGING}/usr/bin
 		sudo chroot ${STAGING} /debootstrap/debootstrap --second-stage
 		sudo chmod -R a+w ${STAGING}/
-		sudo echo "deb http://ftp.debian.org/debian sid main" > ${STAGING}/etc/apt/sources.list
+		sudo echo "deb http://ftp.debian.org/debian ${DISTRO11S_DEB_RELEASE} main" > ${STAGING}/etc/apt/sources.list
 	;;
 	*) echo "Failed for unknown host board ${DISTRO11S_BOARD}"; exit ;;
 	esac


### PR DESCRIPTION
``` diff
From c8f1f53a54918261ee9b3fff13475e205478861f Mon Sep 17 00:00:00 2001
From: Colleen Twitty <colleen@cozybit.com>
Date: Tue, 7 Jan 2014 10:56:57 -0800
Subject: [PATCH] distro11s: add debian release to distro11s.conf

default to sid (unstable)

---
 distro11s.sample.conf    | 3 +++
 scripts/debian-rootfs.sh | 6 +++---
 2 files changed, 6 insertions(+), 3 deletions(-)

diff --git a/distro11s.sample.conf b/distro11s.sample.conf
index 7f6dd32..186c12d 100644
--- a/distro11s.sample.conf
+++ b/distro11s.sample.conf
@@ -4,6 +4,9 @@
 # Target board
 DISTRO11S_BOARD=qemu

+# Debian release to use for building root filesystem (e.g. sid, testing, etc.)
+DISTRO11S_DEB_RELEASE=sid
+
 # Target board memory
 # for example: 128M, 1G
 DISTRO11S_QEMU_MEMORY="128M"
diff --git a/scripts/debian-rootfs.sh b/scripts/debian-rootfs.sh
index f5c1e58..c58d302 100755
--- a/scripts/debian-rootfs.sh
+++ b/scripts/debian-rootfs.sh
@@ -13,14 +13,14 @@ if [ ! -e  ${STAMPS}/debian-rootfs.bootstrapped -o ${FORCE_BUILD} -eq 1 ]; then
    sudo rm -rf ${STAGING}/*
    case ${DISTRO11S_BOARD} in
    zotac | qemu)
-       sudo debootstrap sid ${STAGING} http://ftp.debian.org/debian || exit 1
+       sudo debootstrap ${DISTRO11S_DEB_RELEASE} ${STAGING} http://ftp.debian.org/debian || exit 1
    ;;
    arm-chroot)
-       sudo debootstrap --arch=armel --foreign sid ${STAGING} http://http.debian.net/debian || exit 1
+       sudo debootstrap --arch=armel --foreign ${DISTRO11S_DEB_RELEASE} ${STAGING} http://http.debian.net/debian || exit 1
        sudo cp /usr/bin/qemu-arm-static ${STAGING}/usr/bin
        sudo chroot ${STAGING} /debootstrap/debootstrap --second-stage
        sudo chmod -R a+w ${STAGING}/
-       sudo echo "deb http://ftp.debian.org/debian sid main" > ${STAGING}/etc/apt/sources.list
+       sudo echo "deb http://ftp.debian.org/debian ${DISTRO11S_DEB_RELEASE} main" > ${STAGING}/etc/apt/sources.list
    ;;
    *) echo "Failed for unknown host board ${DISTRO11S_BOARD}"; exit ;;
    esac
-- 
1.8.4.3

```
