### PR TITLE
change from git@github: to git://github/ so non cozybit people can fetch/build

### DIFF
--- a/board/qemu/pkglist
+++ b/board/qemu/pkglist
@@ -5,7 +5,7 @@ iw;git;git://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git;master;
 authsae;git;git://github.com/cozybit/authsae.git;master;
 trace-cmd;git;git://git.kernel.org/pub/scm/linux/kernel/git/rostedt/trace-cmd.git;master;
 wmediumd;git;git://github.com/cozybit/wmediumd.git;master;
-wpa_sup_mesh;git;git@github.com:cozybit/wpa_supplicant.git;master;
+wpa_sup_mesh;git;git://github.com/cozybit/wpa_supplicant.git;master;
 linux-firmware;git;git://git.kernel.org/pub/scm/linux/kernel/git/dwmw2/linux-firmware.git;master;
 mccatool;;;;
 qemu-cleanups;;;;


### PR DESCRIPTION
``` diff
From 27b32d0b1b10c5322099e958bbf8979ae5d6cdf9 Mon Sep 17 00:00:00 2001
From: Jacob Minshall <jacob@cozybit.com>
Date: Tue, 11 Mar 2014 14:14:22 -0700
Subject: [PATCH] change wpa_supplicant repo to the style for public repos

This would not let me fetch without my ssh key and would
eventually break the build since it wouldn't be able to find wpa_sup

---
 board/qemu/pkglist | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/board/qemu/pkglist b/board/qemu/pkglist
index 468df73..0fa457f 100644
--- a/board/qemu/pkglist
+++ b/board/qemu/pkglist
@@ -5,7 +5,7 @@ iw;git;git://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git;master;
 authsae;git;git://github.com/cozybit/authsae.git;master;
 trace-cmd;git;git://git.kernel.org/pub/scm/linux/kernel/git/rostedt/trace-cmd.git;master;
 wmediumd;git;git://github.com/cozybit/wmediumd.git;master;
-wpa_sup_mesh;git;git@github.com:cozybit/wpa_supplicant.git;master;
+wpa_sup_mesh;git;git://github.com/cozybit/wpa_supplicant.git;master;
 linux-firmware;git;git://git.kernel.org/pub/scm/linux/kernel/git/dwmw2/linux-firmware.git;master;
 mccatool;;;;
 qemu-cleanups;;;;
-- 
1.8.3.2

```
