### PR TITLE
distro11s: set crda REGDOMAIN as intended based on distro11s.conf

### DIFF
--- a/scripts/qemu-cleanups.sh
+++ b/scripts/qemu-cleanups.sh
@@ -81,7 +81,7 @@ ssh-keygen -H
 
 # set regulatory domain
 echo "configuring regulatory domain: ${DISTRO11S_REGDOMAIN}"
-echo "sed -i \"s/^REGDOMAIN=/REGDOMAIN=${DISTRO11S_REGDOMAIN}/\" ${STAGING}/etc/default/crda" | sudo sh
+echo "sed -i \"s/^REGDOMAIN=.*/REGDOMAIN=${DISTRO11S_REGDOMAIN}/\" ${STAGING}/etc/default/crda" | sudo sh
 # CRDA debian package expects iw in /usr/sbin/ and /sbin/
 sudo ln -fs ${STAGING}/usr/local/sbin/iw ${STAGING}/usr/sbin/iw
 sudo ln -fs ${STAGING}/usr/local/sbin/iw ${STAGING}/sbin/iw


### PR DESCRIPTION
``` diff
From 4436235a50fa2d8e5257d5aeddd5e838edcd4f5b Mon Sep 17 00:00:00 2001
From: Colleen Twitty <colleen@cozybit.com>
Date: Tue, 18 Mar 2014 08:28:33 -0700
Subject: [PATCH] qemu_cleanups: set crda REGDOMAIN as intended based on
 distro11s.conf

Previously, running qemu-cleanups.sh would append the
DISTRO11S_REGDOMAIN instead of replacing it.  So, if you
ran qemu_cleanups.sh three times you'd have:
"REGDOMAIN=USUSUS" in /etc/default/crda

This fixes the regex so that you'll end up with:
"REGDOMAIN=US"

---
 scripts/qemu-cleanups.sh | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/scripts/qemu-cleanups.sh b/scripts/qemu-cleanups.sh
index 51cfc6f..cc6b1cc 100755
--- a/scripts/qemu-cleanups.sh
+++ b/scripts/qemu-cleanups.sh
@@ -81,7 +81,7 @@ ssh-keygen -H

 # set regulatory domain
 echo "configuring regulatory domain: ${DISTRO11S_REGDOMAIN}"
-echo "sed -i \"s/^REGDOMAIN=/REGDOMAIN=${DISTRO11S_REGDOMAIN}/\" ${STAGING}/etc/default/crda" | sudo sh
+echo "sed -i \"s/^REGDOMAIN=.*/REGDOMAIN=${DISTRO11S_REGDOMAIN}/\" ${STAGING}/etc/default/crda" | sudo sh
 # CRDA debian package expects iw in /usr/sbin/ and /sbin/
 sudo ln -fs ${STAGING}/usr/local/sbin/iw ${STAGING}/usr/sbin/iw
 sudo ln -fs ${STAGING}/usr/local/sbin/iw ${STAGING}/sbin/iw
-- 
1.8.4.3

```
